### PR TITLE
feat: add quotes to array keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+.idea
+
+.idea/*
+# User-specific stuff:
+.idea/workspace.xml
+.idea/modules.xml
+.idea/tasks.xml
+.idea/php.xml
+.idea/dictionaries
+.idea/dictionaries/*
+.idea/vcs.xml
+.idea/misc.xml
+.idea/gearfest-site.iml
+.idea/jsLibraryMappings.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml

--- a/report/CommentReport.php
+++ b/report/CommentReport.php
@@ -7,24 +7,24 @@
     function __construct() {
       $this->report = array();
       $this->report[0] = array (
-          header=> "Comments about candy",
-          commentRecords=> array()
+          'header'=> "Comments about candy",
+          'commentRecords'=> array()
       );
       $this->report[1] = array (
-          header=> "Comments about call me / don't call me",
-          commentRecords=> array()
+          'header'=> "Comments about call me / don't call me",
+          'commentRecords'=> array()
       );
       $this->report[2] = array (
-          header=> "Comments about who referred me",
-          commentRecords=> array()
+          'header'=> "Comments about who referred me",
+          'commentRecords'=> array()
       );
       $this->report[3] = array (
-          header=> "Comments about signature requirements upon delivery",
-          commentRecords=> array()
+          'header'=> "Comments about signature requirements upon delivery",
+          'commentRecords'=> array()
       );
       $this->report[4] = array (
-          header=> "Miscellaneous comments",
-          commentRecords=> array()
+          'header'=> "Miscellaneous comments",
+          'commentRecords'=> array()
       );
       $this->generateReport();
     }
@@ -53,9 +53,9 @@
         $x = 0;
         while($row = $result->fetch_assoc()) {
           $commentRecords[$x] = array (
-            orderid  => $row["orderid"],
-            comment  => $row["comments"],
-            shipdate => $row["shipdate_expected"]
+            'orderid' => $row["orderid"],
+            'comment'  => $row["comments"],
+            'shipdate' => $row["shipdate_expected"]
           );
           $x++;
         }

--- a/utility/FixShipDate.php
+++ b/utility/FixShipDate.php
@@ -56,8 +56,8 @@
         $x = 0;
         while($row = $result->fetch_assoc()) {
           $fixRecords[$x] = array (
-            orderid  => $row["orderid"],
-            comment  => $row["comments"]
+            'orderid'  => $row["orderid"],
+            'comment'  => $row["comments"]
           );
           $x++;
         }


### PR DESCRIPTION
Using array key names without quotes is a legacy feature in PHP. It was originally the way to do it, but it is no longer recommended and is only still supported for backward compatibility. (breaks in php 7.3). I just added a .gitignore and fixed the quotes. No big deal! 